### PR TITLE
change query depending on field type

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -24,8 +24,23 @@ module Administrate
         table_name = query_table_name(attr)
         attr_name = column_to_query(attr)
 
-        "LOWER(CAST(#{table_name}.#{attr_name} AS CHAR(256))) LIKE ?"
+        query_for_attribute(attribute_types[attr], "#{table_name}.#{attr_name}")
       end.join(" OR ")
+    end
+
+    def query_for_attribute(attribute, field)
+      attribute_class =
+          if attribute.is_a?(Administrate::Field::Deferred)
+            attribute.deferred_class
+          else
+            attribute.class
+          end
+
+      if attribute_class == Administrate::Field::Number
+        "CAST(#{field} AS CHAR(256)) ILIKE ?"
+      else
+        "#{field} ILIKE ?"
+      end
     end
 
     def search_terms


### PR DESCRIPTION
In order to speed up the search :

* the LOWER sql method has been replaced by an ILIKE search
* the CAST sql method is only done for `Number` fields