### PR TITLE
Fix belongs_to search by id

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -31,7 +31,12 @@ module Administrate
     def query_for_attribute(attribute, field)
       attribute_class =
           if attribute.is_a?(Administrate::Field::Deferred)
-            attribute.deferred_class
+            # HACK: make search work for belongs_to attribute searching by id
+            if attribute.searchable_field == :id
+              Administrate::Field::Number
+            else
+              attribute.deferred_class
+            end
           else
             attribute.class
           end


### PR DESCRIPTION
Before this PR, having:
```ruby
class ParkingDashboard < ApplicationDashboard
  ATTRIBUTE_TYPES = {
    listing:
      Field::BelongsTo.with_options(searchable: true, searchable_field: :id),
```
Makes search fail, because it raises this error:
```sql
PG::UndefinedFunction: ERROR:  operator does not exist: bigint ~~* unknown
LINE 1: ... = "parkings"."listing_id" WHERE ("listings"."id" ILIKE '%36...
```

This PR fixes it with a hack by recognising correctly the `:id` field and casting it before doing the comparison.